### PR TITLE
Sort lists of failed edges and vertices at end of graph construction

### DIFF
--- a/descartes_light/include/descartes_light/impl/descartes_light.hpp
+++ b/descartes_light/include/descartes_light/impl/descartes_light.hpp
@@ -22,6 +22,7 @@
 #include "descartes_light/ladder_graph_dag_search.h"
 #include <console_bridge/console.h>
 #include <sstream>
+#include <algorithm>
 
 static void reportFailedEdges(const std::vector<std::size_t>& indices)
 {
@@ -127,6 +128,9 @@ bool Solver<FloatType>::build(const std::vector<typename PositionSampler<FloatTy
     }
 #endif
   }
+
+  std::sort(failed_vertices_.begin(), failed_vertices_.end());
+  std::sort(failed_edges_.begin(), failed_edges_.end());
 
   reportFailedVertices(failed_vertices_);
   reportFailedEdges(failed_edges_);


### PR DESCRIPTION
Sort the indices of failed edges and vertices in increasing order before reporting them. This makes the output when graph construction fails a little more useful and comprehensible, e.g. when trying to answer the question "are all 1000 of my vertices failing or merely 990 of them".