### PR TITLE
Fix incorrect initial index in EuclideanDistanceEdgeEvaluator when iterating through DOFs

### DIFF
--- a/descartes_samplers/include/descartes_samplers/evaluators/impl/euclidean_distance_edge_evaluator.hpp
+++ b/descartes_samplers/include/descartes_samplers/evaluators/impl/euclidean_distance_edge_evaluator.hpp
@@ -31,7 +31,7 @@ static void considerEdge(const FloatType* start,
                          typename descartes_light::LadderGraph<FloatType>::EdgeList& out)
 {
   FloatType cost = 0.0;
-  for (std::size_t i = 2; i < dof; ++i)
+  for (std::size_t i = 0; i < dof; ++i)
   {
     cost += std::pow(end[i] - start[i], 2);
   }


### PR DESCRIPTION
Should start at zero index so that all robot DOFs are included when calculating edge cost.