### PR TITLE
Euclidean distance edge scale

### DIFF
--- a/descartes_light/edge_evaluators/include/descartes_light/edge_evaluators/euclidean_distance_edge_evaluator.h
+++ b/descartes_light/edge_evaluators/include/descartes_light/edge_evaluators/euclidean_distance_edge_evaluator.h
@@ -22,14 +22,23 @@
 
 namespace descartes_light
 {
+/**
+ * @brief Computes the cost of an edge between two waypoints as the squared Euclidean distance between them.
+ * This distance can also be multiplied by an input scale factor in the case of varying units within the elements of the
+ * states (such as linear and revolute joints of a robot)
+ */
 template <typename FloatType>
 class EuclideanDistanceEdgeEvaluator : public EdgeEvaluator<FloatType>
 {
 public:
   EuclideanDistanceEdgeEvaluator() = default;
+  EuclideanDistanceEdgeEvaluator(const Eigen::Array<FloatType, Eigen::Dynamic, 1>& scale);
 
   std::pair<bool, FloatType> evaluate(const Eigen::Matrix<FloatType, Eigen::Dynamic, 1>& start,
                                       const Eigen::Matrix<FloatType, Eigen::Dynamic, 1>& end) const override;
+
+private:
+  const Eigen::Array<FloatType, Eigen::Dynamic, 1> scale_;
 };
 
 using EuclideanDistanceEdgeEvaluatorF = EuclideanDistanceEdgeEvaluator<float>;

--- a/descartes_light/edge_evaluators/include/descartes_light/edge_evaluators/impl/euclidean_distance_edge_evaluator.hpp
+++ b/descartes_light/edge_evaluators/include/descartes_light/edge_evaluators/impl/euclidean_distance_edge_evaluator.hpp
@@ -28,12 +28,23 @@ DESCARTES_IGNORE_WARNINGS_POP
 namespace descartes_light
 {
 template <typename FloatType>
+EuclideanDistanceEdgeEvaluator<FloatType>::EuclideanDistanceEdgeEvaluator(
+    const Eigen::Array<FloatType, Eigen::Dynamic, 1>& scale)
+  : scale_(scale)
+{
+}
+
+template <typename FloatType>
 std::pair<bool, FloatType>
 EuclideanDistanceEdgeEvaluator<FloatType>::evaluate(const Eigen::Matrix<FloatType, Eigen::Dynamic, 1>& start,
                                                     const Eigen::Matrix<FloatType, Eigen::Dynamic, 1>& end) const
 {
-  FloatType cost = (end - start).squaredNorm();
-  return std::make_pair(true, cost);
+  Eigen::Matrix<FloatType, Eigen::Dynamic, 1> diff = end - start;
+  if (scale_.size() == diff.size())
+  {
+    diff.array() *= scale_;
+  }
+  return std::make_pair(true, diff.squaredNorm());
 }
 
 }  // namespace descartes_light


### PR DESCRIPTION
Adds scale vector to the Euclidean distance edge evaluator to support comparing states with mixed units (i.e. linear and revolute joints) more appropriately

Merge after #51 