### PR TITLE
Visitor Templates for BGL Solver

### DIFF
--- a/descartes_light/solvers/include/descartes_light/solvers/bgl/bgl_dijkstra_solver.h
+++ b/descartes_light/solvers/include/descartes_light/solvers/bgl/bgl_dijkstra_solver.h
@@ -2,6 +2,7 @@
 #define DESCARTES_LIGHT_SOLVERS_BGL_BGL_DIJKSTRA_SOLVER_H
 
 #include <descartes_light/solvers/bgl/bgl_solver.h>
+#include <descartes_light/solvers/bgl/event_visitors.h>
 
 namespace descartes_light
 {
@@ -9,68 +10,33 @@ namespace descartes_light
  * @brief BGL solver implementation that constructs vertices and edges in the build function and uses Dijkstra's
  * algorithm with a default visitor to search the graph
  */
-template <typename FloatType>
-class BGLDijkstraSVSESolver : public BGLSolverBaseSVSE<FloatType>
+template <typename FloatType, typename Visitors>
+class BGLDijkstraSVSESolver : public BGLSolverBaseSVSE<FloatType, Visitors>
 {
 public:
-  using BGLSolverBaseSVSE<FloatType>::BGLSolverBaseSVSE;
+  using BGLSolverBaseSVSE<FloatType, Visitors>::BGLSolverBaseSVSE;
 
   SearchResult<FloatType> search() override;
 };
 
-using BGLDijkstraSVSESolverF = BGLDijkstraSVSESolver<float>;
-using BGLDijkstraSVSESolverD = BGLDijkstraSVSESolver<double>;
-
-/**
- * @brief BGL solver implementation that constructs vertices and edges in the build function and uses Dijkstra's
- * algorithm with a visitor that terminates the search once a vertex in the last rung of the graph is encountered rather
- * than allowing it to continue until the distance to all nodes in the graph has been calculated
- */
-template <typename FloatType>
-class BGLEfficientDijkstraSVSESolver : public BGLSolverBaseSVSE<FloatType>
-{
-public:
-  using BGLSolverBaseSVSE<FloatType>::BGLSolverBaseSVSE;
-
-  SearchResult<FloatType> search() override;
-};
-
-using BGLEfficientDijkstraSVSESolverF = BGLEfficientDijkstraSVSESolver<float>;
-using BGLEfficientDijkstraSVSESolverD = BGLEfficientDijkstraSVSESolver<double>;
+using BGLDijkstraSVSESolverF = BGLDijkstraSVSESolver<float, early_terminator<float, boost::on_examine_vertex>>;
+using BGLDijkstraSVSESolverD = BGLDijkstraSVSESolver<double, early_terminator<double, boost::on_examine_vertex>>;
 
 /**
  * @brief BGL solver implementation that constructs vertices build function and uses Dijkstra's
  * algorithm with an edge-adding visitor to search the graph
  */
-template <typename FloatType>
-class BGLDijkstraSVDESolver : public BGLSolverBaseSVDE<FloatType>
+template <typename FloatType, typename Visitors>
+class BGLDijkstraSVDESolver : public BGLSolverBaseSVDE<FloatType, Visitors>
 {
 public:
-  using BGLSolverBaseSVDE<FloatType>::BGLSolverBaseSVDE;
+  using BGLSolverBaseSVDE<FloatType, Visitors>::BGLSolverBaseSVDE;
 
   SearchResult<FloatType> search() override;
 };
 
-using BGLDijkstraSVDESolverF = BGLDijkstraSVDESolver<float>;
-using BGLDijkstraSVDESolverD = BGLDijkstraSVDESolver<double>;
-
-/**
- * @brief BGL solver implementation that constructs vertices in the build function and uses Dijkstra's
- * algorithm with a visitor that adds edges and terminates the search once a vertex in the last rung of
- * the graph is encountered rather than allowing it to continue until the distance to all nodes in the
- * graph has been calculated
- */
-template <typename FloatType>
-class BGLEfficientDijkstraSVDESolver : public BGLSolverBaseSVDE<FloatType>
-{
-public:
-  using BGLSolverBaseSVDE<FloatType>::BGLSolverBaseSVDE;
-
-  SearchResult<FloatType> search() override;
-};
-
-using BGLEfficientDijkstraSVDESolverF = BGLEfficientDijkstraSVDESolver<float>;
-using BGLEfficientDijkstraSVDESolverD = BGLEfficientDijkstraSVDESolver<double>;
+using BGLDijkstraSVDESolverF = BGLDijkstraSVDESolver<float, early_terminator<float, boost::on_examine_vertex>>;
+using BGLDijkstraSVDESolverD = BGLDijkstraSVDESolver<double, early_terminator<double, boost::on_examine_vertex>>;
 
 }  // namespace descartes_light
 

--- a/descartes_light/solvers/include/descartes_light/solvers/bgl/bgl_dijkstra_solver.h
+++ b/descartes_light/solvers/include/descartes_light/solvers/bgl/bgl_dijkstra_solver.h
@@ -19,8 +19,8 @@ public:
   SearchResult<FloatType> search() override;
 };
 
-using BGLDijkstraSVSESolverF = BGLDijkstraSVSESolver<float, early_terminator<float, boost::on_examine_vertex>>;
-using BGLDijkstraSVSESolverD = BGLDijkstraSVSESolver<double, early_terminator<double, boost::on_examine_vertex>>;
+using BGLDijkstraSVSESolverF = BGLDijkstraSVSESolver<float, early_terminator<boost::on_examine_vertex>>;
+using BGLDijkstraSVSESolverD = BGLDijkstraSVSESolver<double, early_terminator<boost::on_examine_vertex>>;
 
 /**
  * @brief BGL solver implementation that constructs vertices build function and uses Dijkstra's
@@ -35,8 +35,8 @@ public:
   SearchResult<FloatType> search() override;
 };
 
-using BGLDijkstraSVDESolverF = BGLDijkstraSVDESolver<float, early_terminator<float, boost::on_examine_vertex>>;
-using BGLDijkstraSVDESolverD = BGLDijkstraSVDESolver<double, early_terminator<double, boost::on_examine_vertex>>;
+using BGLDijkstraSVDESolverF = BGLDijkstraSVDESolver<float, early_terminator<boost::on_examine_vertex>>;
+using BGLDijkstraSVDESolverD = BGLDijkstraSVDESolver<double, early_terminator<boost::on_examine_vertex>>;
 
 }  // namespace descartes_light
 

--- a/descartes_light/solvers/include/descartes_light/solvers/bgl/bgl_solver.h
+++ b/descartes_light/solvers/include/descartes_light/solvers/bgl/bgl_solver.h
@@ -31,11 +31,11 @@ namespace descartes_light
 /**
  * @brief Partial implementation for solvers leveraging the Boost Graph Library
  */
-template <typename FloatType>
+template <typename FloatType, typename Visitors>
 class BGLSolverBase : public Solver<FloatType>
 {
 public:
-  BGLSolverBase(unsigned num_threads = std::thread::hardware_concurrency());
+  BGLSolverBase(Visitors event_visitors, unsigned num_threads = std::thread::hardware_concurrency());
 
   inline const BGLGraph<FloatType>& getGraph() const { return graph_; }
 
@@ -56,6 +56,9 @@ protected:
    */
   std::vector<typename State<FloatType>::ConstPtr> toStates(const std::vector<VertexDesc<FloatType>>& path) const;
 
+  /** @brief Event visitors for custom behavior in the search */
+  Visitors event_visitors_;
+  /** @brief Number of threads for parallel processing */
   unsigned num_threads_;
   /** @brief Graph representation of the planning problem */
   BGLGraph<FloatType> graph_;
@@ -73,11 +76,11 @@ protected:
  * @details Constructs only vertices in the build function (i.e. statically) with the assumption that edges will be
  * added during the search (i.e. dynamically)
  */
-template <typename FloatType>
-class BGLSolverBaseSVDE : public BGLSolverBase<FloatType>
+template <typename FloatType, typename Visitors>
+class BGLSolverBaseSVDE : public BGLSolverBase<FloatType, Visitors>
 {
 public:
-  using BGLSolverBase<FloatType>::BGLSolverBase;
+  using BGLSolverBase<FloatType, Visitors>::BGLSolverBase;
 
   BuildStatus buildImpl(const std::vector<typename WaypointSampler<FloatType>::ConstPtr>& trajectory,
                         const std::vector<typename EdgeEvaluator<FloatType>::ConstPtr>& edge_eval,
@@ -91,11 +94,11 @@ protected:
  * @brief BGL solver Static Vertex Static Edge (SVSE) partial implementation
  * @details Constructs both vertices and edges in the build function (i.e. statically)
  */
-template <typename FloatType>
-class BGLSolverBaseSVSE : public BGLSolverBaseSVDE<FloatType>
+template <typename FloatType, typename Visitors>
+class BGLSolverBaseSVSE : public BGLSolverBaseSVDE<FloatType, Visitors>
 {
 public:
-  using BGLSolverBaseSVDE<FloatType>::BGLSolverBaseSVDE;
+  using BGLSolverBaseSVDE<FloatType, Visitors>::BGLSolverBaseSVDE;
 
   BuildStatus buildImpl(const std::vector<typename WaypointSampler<FloatType>::ConstPtr>& trajectory,
                         const std::vector<typename EdgeEvaluator<FloatType>::ConstPtr>& edge_eval,

--- a/descartes_light/solvers/include/descartes_light/solvers/bgl/event_visitor.h
+++ b/descartes_light/solvers/include/descartes_light/solvers/bgl/event_visitor.h
@@ -1,4 +1,0 @@
-#ifndef EVENT_VISITOR_H
-#define EVENT_VISITOR_H
-
-#endif  // EVENT_VISITOR_H

--- a/descartes_light/solvers/include/descartes_light/solvers/bgl/event_visitors.h
+++ b/descartes_light/solvers/include/descartes_light/solvers/bgl/event_visitors.h
@@ -1,0 +1,64 @@
+#ifndef DESCARTES_LIGHT_SOLVERS_BGL_EVENT_VISITORS
+#define DESCARTES_LIGHT_SOLVERS_BGL_EVENT_VISITORS
+
+#include <descartes_light/solvers/bgl/boost_graph_types.h>
+
+#include <descartes_light/descartes_macros.h>
+DESCARTES_IGNORE_WARNINGS_PUSH
+#include <boost/graph/visitors.hpp>
+DESCARTES_IGNORE_WARNINGS_POP
+
+namespace descartes_light
+{
+/**
+ * @brief Event visitor that terminates the search when a vertex in the last rung of the graph is examined
+ * @details Throws the vertex descriptor that is the termination of the path once a vertex in the last rung of
+ * the graph is operated on
+ */
+template <typename FloatType, typename EventType>
+struct early_terminator : public boost::base_visitor<early_terminator<FloatType, EventType>>
+{
+  /** @brief Event filter typedef defining the events for which this visitor can be used */
+  typedef EventType event_filter;
+
+  early_terminator(long last_rung_idx);
+
+  void operator()(VertexDesc<FloatType> u, const BGLGraph<FloatType>& g);
+
+  const long last_rung_idx_;
+};
+
+/**
+ * @brief Event visitor that adds all edges to each vertex dynamically as the vertex is discovered during the graph
+ * search
+ */
+template <typename FloatType, typename EventType>
+struct add_all_edges_dynamically : public boost::base_visitor<add_all_edges_dynamically<FloatType, EventType>>
+{
+  /** @brief Event filter typedef defining the events for which this visitor can be used */
+  typedef EventType event_filter;
+
+  add_all_edges_dynamically(std::vector<typename EdgeEvaluator<FloatType>::ConstPtr> edge_eval,
+                            std::vector<std::vector<VertexDesc<FloatType>>> ladder_rungs);
+
+  void operator()(VertexDesc<FloatType> u, const BGLGraph<FloatType>& g);
+
+  const std::vector<typename EdgeEvaluator<FloatType>::ConstPtr> eval_;
+  const std::vector<std::vector<VertexDesc<FloatType>>> ladder_rungs_;
+};
+
+/**
+ * @brief Event visitor for updating vertex cost
+ */
+template <typename FloatType>
+struct cost_recorder : public boost::base_visitor<cost_recorder<FloatType>>
+{
+  /** @brief Event filter typedef defining the events for which this visitor can be used */
+  typedef boost::on_tree_edge event_filter;
+
+  void operator()(EdgeDesc<FloatType> e, const BGLGraph<FloatType>& g);
+};
+
+}  // namespace descartes_light
+
+#endif  // DESCARTES_LIGHT_SOLVERS_BGL_EVENT_VISITORS_H

--- a/descartes_light/solvers/include/descartes_light/solvers/bgl/event_visitors.h
+++ b/descartes_light/solvers/include/descartes_light/solvers/bgl/event_visitors.h
@@ -23,7 +23,7 @@ struct early_terminator : public boost::base_visitor<early_terminator<EventType>
 
   early_terminator(long last_rung_idx);
 
-  template<typename FloatType>
+  template <typename FloatType>
   void operator()(VertexDesc<FloatType> u, const BGLGraph<FloatType>& g);
 
   const long last_rung_idx_;
@@ -56,7 +56,7 @@ struct cost_recorder : public boost::base_visitor<cost_recorder>
   /** @brief Event filter typedef defining the events for which this visitor can be used */
   typedef boost::on_tree_edge event_filter;
 
-  template<typename FloatType>
+  template <typename FloatType>
   void operator()(EdgeDesc<FloatType> e, const BGLGraph<FloatType>& g);
 };
 

--- a/descartes_light/solvers/include/descartes_light/solvers/bgl/event_visitors.h
+++ b/descartes_light/solvers/include/descartes_light/solvers/bgl/event_visitors.h
@@ -15,14 +15,15 @@ namespace descartes_light
  * @details Throws the vertex descriptor that is the termination of the path once a vertex in the last rung of
  * the graph is operated on
  */
-template <typename FloatType, typename EventType>
-struct early_terminator : public boost::base_visitor<early_terminator<FloatType, EventType>>
+template <typename EventType>
+struct early_terminator : public boost::base_visitor<early_terminator<EventType>>
 {
   /** @brief Event filter typedef defining the events for which this visitor can be used */
   typedef EventType event_filter;
 
   early_terminator(long last_rung_idx);
 
+  template<typename FloatType>
   void operator()(VertexDesc<FloatType> u, const BGLGraph<FloatType>& g);
 
   const long last_rung_idx_;
@@ -50,12 +51,12 @@ struct add_all_edges_dynamically : public boost::base_visitor<add_all_edges_dyna
 /**
  * @brief Event visitor for updating vertex cost
  */
-template <typename FloatType>
-struct cost_recorder : public boost::base_visitor<cost_recorder<FloatType>>
+struct cost_recorder : public boost::base_visitor<cost_recorder>
 {
   /** @brief Event filter typedef defining the events for which this visitor can be used */
   typedef boost::on_tree_edge event_filter;
 
+  template<typename FloatType>
   void operator()(EdgeDesc<FloatType> e, const BGLGraph<FloatType>& g);
 };
 

--- a/descartes_light/solvers/include/descartes_light/solvers/bgl/impl/bgl_dijkstra_solver.hpp
+++ b/descartes_light/solvers/include/descartes_light/solvers/bgl/impl/bgl_dijkstra_solver.hpp
@@ -11,87 +11,32 @@ DESCARTES_IGNORE_WARNINGS_POP
 
 namespace descartes_light
 {
-template <typename FloatType>
-SearchResult<FloatType> BGLDijkstraSVSESolver<FloatType>::search()
+template <typename FloatType, typename Visitors>
+static VertexDesc<FloatType> solveDijkstra(BGLGraph<FloatType>& graph,
+                                           std::vector<VertexDesc<FloatType>>& predecessors,
+                                           const VertexDesc<FloatType>& source,
+                                           const Visitors& event_visitors,
+                                           const std::vector<std::vector<VertexDesc<FloatType>>>& ladder_rungs)
 {
-  // Convenience aliases
-  auto& graph_ = BGLSolverBase<FloatType>::graph_;
-  const auto& source_ = BGLSolverBase<FloatType>::source_;
-  auto& predecessors_ = BGLSolverBase<FloatType>::predecessors_;
-  const auto& ladder_rungs_ = BGLSolverBase<FloatType>::ladder_rungs_;
-
   // Internal properties
-  auto index_prop_map = boost::get(boost::vertex_index, graph_);
-  auto weight_prop_map = boost::get(boost::edge_weight, graph_);
-  auto color_prop_map = boost::get(&Vertex<FloatType>::color, graph_);
-  auto distance_prop_map = boost::get(&Vertex<FloatType>::distance, graph_);
+  auto index_prop_map = boost::get(boost::vertex_index, graph);
+  auto weight_prop_map = boost::get(boost::edge_weight, graph);
+  auto color_prop_map = boost::get(&Vertex<FloatType>::color, graph);
+  auto distance_prop_map = boost::get(&Vertex<FloatType>::distance, graph);
+
+  predecessors.resize(boost::num_vertices(graph), std::numeric_limits<std::size_t>::max());
 
   typedef typename boost::property_map<BGLGraph<FloatType>, boost::vertex_index_t>::type IndexMap;
   typedef boost::iterator_property_map<typename std::vector<VertexDesc<FloatType>>::iterator, IndexMap> PredecessorMap;
-  predecessors_.resize(boost::num_vertices(graph_), std::numeric_limits<std::size_t>::max());
-  PredecessorMap predecessor_it_map = boost::make_iterator_property_map(predecessors_.begin(), index_prop_map);
+  PredecessorMap predecessor_it_map = boost::make_iterator_property_map(predecessors.begin(), index_prop_map);
 
-  // Perform the search
-  boost::dijkstra_shortest_paths(graph_,
-                                 source_,
-                                 predecessor_it_map,
-                                 distance_prop_map,
-                                 weight_prop_map,
-                                 index_prop_map,
-                                 std::less<>(),
-                                 std::plus<>(),
-                                 std::numeric_limits<FloatType>::max(),
-                                 static_cast<FloatType>(0.0),
-                                 boost::default_dijkstra_visitor(),
-                                 color_prop_map);
-
-  // Find lowest cost node in last rung
-  auto target = std::min_element(ladder_rungs_.back().begin(),
-                                 ladder_rungs_.back().end(),
-                                 [&](const VertexDesc<FloatType>& a, const VertexDesc<FloatType>& b) {
-                                   return graph_[a].distance < graph_[b].distance;
-                                 });
-
-  SearchResult<FloatType> result;
-
-  // Reconstruct the path from the predecesor map; remove the artificial start state
-  const auto vd_path = BGLSolverBase<FloatType>::reconstructPath(source_, *target);
-  result.trajectory = BGLSolverBase<FloatType>::toStates(vd_path);
-  result.trajectory.erase(result.trajectory.begin());
-
-  result.cost = graph_[*target].distance;
-
-  return result;
-}
-
-template <typename FloatType>
-SearchResult<FloatType> BGLEfficientDijkstraSVSESolver<FloatType>::search()
-{
-  // Convenience aliases
-  auto& graph_ = BGLSolverBase<FloatType>::graph_;
-  const auto& source_ = BGLSolverBase<FloatType>::source_;
-  auto& predecessors_ = BGLSolverBase<FloatType>::predecessors_;
-  const auto& ladder_rungs_ = BGLSolverBase<FloatType>::ladder_rungs_;
-
-  // Internal properties
-  auto index_prop_map = boost::get(boost::vertex_index, graph_);
-  auto weight_prop_map = boost::get(boost::edge_weight, graph_);
-  auto color_prop_map = boost::get(&Vertex<FloatType>::color, graph_);
-  auto distance_prop_map = boost::get(&Vertex<FloatType>::distance, graph_);
-
-  typedef typename boost::property_map<BGLGraph<FloatType>, boost::vertex_index_t>::type IndexMap;
-  typedef boost::iterator_property_map<typename std::vector<VertexDesc<FloatType>>::iterator, IndexMap> PredecessorMap;
-  predecessors_.resize(boost::num_vertices(graph_), std::numeric_limits<std::size_t>::max());
-  PredecessorMap predecessor_it_map = boost::make_iterator_property_map(predecessors_.begin(), index_prop_map);
-
-  const long last_rung_idx = static_cast<long>(ladder_rungs_.size() - 1);
-  auto visitor = boost::make_dijkstra_visitor(early_terminator<FloatType, boost::on_examine_vertex>(last_rung_idx));
+  auto visitor = boost::make_dijkstra_visitor(event_visitors);
 
   // Perform the search
   try
   {
-    boost::dijkstra_shortest_paths(graph_,
-                                   source_,
+    boost::dijkstra_shortest_paths(graph,
+                                   source,
                                    predecessor_it_map,
                                    distance_prop_map,
                                    weight_prop_map,
@@ -102,140 +47,78 @@ SearchResult<FloatType> BGLEfficientDijkstraSVSESolver<FloatType>::search()
                                    static_cast<FloatType>(0.0),
                                    visitor,
                                    color_prop_map);
+
+    // In the case that the visitor does not throw the target vertex descriptor, find the lowest cost vertex in last
+    // rung of the ladder graph
+    auto target = std::min_element(ladder_rungs.back().begin(),
+                                   ladder_rungs.back().end(),
+                                   [&](const VertexDesc<FloatType>& a, const VertexDesc<FloatType>& b) {
+                                     return graph[a].distance < graph[b].distance;
+                                   });
+    if (target != ladder_rungs.back().end())
+      throw *target;
   }
   catch (const VertexDesc<FloatType>& target)
   {
-    SearchResult<FloatType> result;
-
-    // Reconstruct the path from the predecesor map; remove the artificial start state
-    const auto vd_path = BGLSolverBase<FloatType>::reconstructPath(source_, target);
-    result.trajectory = BGLSolverBase<FloatType>::toStates(vd_path);
-    result.trajectory.erase(result.trajectory.begin());
-
-    result.cost = graph_[target].distance;
-
-    return result;
+    return target;
   }
 
   // If the visitor never threw the vertex descriptor, there was an issue with the search
   throw std::runtime_error("Search failed to encounter vertex associated with the last waypoint in the trajectory");
 }
 
-template <typename FloatType>
-SearchResult<FloatType> BGLDijkstraSVDESolver<FloatType>::search()
+template <typename FloatType, typename Visitors>
+SearchResult<FloatType> BGLDijkstraSVSESolver<FloatType, Visitors>::search()
 {
   // Convenience aliases
-  auto& graph_ = BGLSolverBase<FloatType>::graph_;
-  const auto& source_ = BGLSolverBase<FloatType>::source_;
-  auto& predecessors_ = BGLSolverBase<FloatType>::predecessors_;
-  auto& ladder_rungs_ = BGLSolverBase<FloatType>::ladder_rungs_;
-  auto& edge_eval_ = BGLSolverBaseSVDE<FloatType>::edge_eval_;
+  auto& graph_ = BGLSolverBase<FloatType, Visitors>::graph_;
+  const auto& source_ = BGLSolverBase<FloatType, Visitors>::source_;
+  auto& predecessors_ = BGLSolverBase<FloatType, Visitors>::predecessors_;
+  const auto& ladder_rungs_ = BGLSolverBase<FloatType, Visitors>::ladder_rungs_;
+  const auto& event_visitors_ = BGLSolverBase<FloatType, Visitors>::event_visitors_;
 
-  // Internal properties
-  auto index_prop_map = boost::get(boost::vertex_index, graph_);
-  auto weight_prop_map = boost::get(boost::edge_weight, graph_);
-  auto color_prop_map = boost::get(&Vertex<FloatType>::color, graph_);
-  auto distance_prop_map = boost::get(&Vertex<FloatType>::distance, graph_);
-
-  typedef typename boost::property_map<BGLGraph<FloatType>, boost::vertex_index_t>::type IndexMap;
-  typedef boost::iterator_property_map<typename std::vector<VertexDesc<FloatType>>::iterator, IndexMap> PredecessorMap;
-  predecessors_.resize(boost::num_vertices(graph_), std::numeric_limits<std::size_t>::max());
-  PredecessorMap predecessor_it_map = boost::make_iterator_property_map(predecessors_.begin(), index_prop_map);
-
-  auto visitor = boost::make_dijkstra_visitor(
-      add_all_edges_dynamically<FloatType, boost::on_examine_vertex>(edge_eval_, ladder_rungs_));
-
-  // Perform the search
-  boost::dijkstra_shortest_paths(graph_,
-                                 source_,
-                                 predecessor_it_map,
-                                 distance_prop_map,
-                                 weight_prop_map,
-                                 index_prop_map,
-                                 std::less<>(),
-                                 std::plus<>(),
-                                 std::numeric_limits<FloatType>::max(),
-                                 static_cast<FloatType>(0.0),
-                                 visitor,
-                                 color_prop_map);
-
-  // Find lowest cost node in last rung
-  auto target = std::min_element(ladder_rungs_.back().begin(),
-                                 ladder_rungs_.back().end(),
-                                 [&](const VertexDesc<FloatType>& a, const VertexDesc<FloatType>& b) {
-                                   return graph_[a].distance < graph_[b].distance;
-                                 });
+  VertexDesc<FloatType> target =
+      solveDijkstra<FloatType, Visitors>(graph_, predecessors_, source_, event_visitors_, ladder_rungs_);
 
   SearchResult<FloatType> result;
 
   // Reconstruct the path from the predecesor map; remove the artificial start state
-  const auto vd_path = BGLSolverBase<FloatType>::reconstructPath(source_, *target);
-  result.trajectory = BGLSolverBase<FloatType>::toStates(vd_path);
+  const auto vd_path = BGLSolverBase<FloatType, Visitors>::reconstructPath(source_, target);
+  result.trajectory = BGLSolverBase<FloatType, Visitors>::toStates(vd_path);
   result.trajectory.erase(result.trajectory.begin());
 
-  result.cost = graph_[*target].distance;
+  result.cost = graph_[target].distance;
 
   return result;
 }
 
-template <typename FloatType>
-SearchResult<FloatType> BGLEfficientDijkstraSVDESolver<FloatType>::search()
+template <typename FloatType, typename Visitors>
+SearchResult<FloatType> BGLDijkstraSVDESolver<FloatType, Visitors>::search()
 {
   // Convenience aliases
-  auto& graph_ = BGLSolverBase<FloatType>::graph_;
-  const auto& source_ = BGLSolverBase<FloatType>::source_;
-  auto& predecessors_ = BGLSolverBase<FloatType>::predecessors_;
-  auto& ladder_rungs_ = BGLSolverBase<FloatType>::ladder_rungs_;
-  auto& edge_eval_ = BGLSolverBaseSVDE<FloatType>::edge_eval_;
+  auto& graph_ = BGLSolverBase<FloatType, Visitors>::graph_;
+  const auto& source_ = BGLSolverBase<FloatType, Visitors>::source_;
+  auto& predecessors_ = BGLSolverBase<FloatType, Visitors>::predecessors_;
+  const auto& ladder_rungs_ = BGLSolverBase<FloatType, Visitors>::ladder_rungs_;
+  const auto& event_visitors_ = BGLSolverBase<FloatType, Visitors>::event_visitors_;
 
-  // Internal properties
-  auto index_prop_map = boost::get(boost::vertex_index, graph_);
-  auto weight_prop_map = boost::get(boost::edge_weight, graph_);
-  auto color_prop_map = boost::get(&Vertex<FloatType>::color, graph_);
-  auto distance_prop_map = boost::get(&Vertex<FloatType>::distance, graph_);
+  // Create the dynamic edge adding event visitor
+  const auto& edge_eval_ = BGLSolverBaseSVDE<FloatType, Visitors>::edge_eval_;
+  auto vis = std::make_pair(add_all_edges_dynamically<FloatType, boost::on_examine_vertex>(edge_eval_, ladder_rungs_),
+                            event_visitors_);
 
-  typedef typename boost::property_map<BGLGraph<FloatType>, boost::vertex_index_t>::type IndexMap;
-  typedef boost::iterator_property_map<typename std::vector<VertexDesc<FloatType>>::iterator, IndexMap> PredecessorMap;
-  predecessors_.resize(boost::num_vertices(graph_), std::numeric_limits<std::size_t>::max());
-  PredecessorMap predecessor_it_map = boost::make_iterator_property_map(predecessors_.begin(), index_prop_map);
+  VertexDesc<FloatType> target = solveDijkstra(graph_, predecessors_, source_, vis, ladder_rungs_);
 
-  const long last_rung_idx = static_cast<long>(ladder_rungs_.size() - 1);
-  auto visitor = boost::make_dijkstra_visitor(
-      std::make_pair(early_terminator<FloatType, boost::on_examine_vertex>(last_rung_idx),
-                     add_all_edges_dynamically<FloatType, boost::on_examine_vertex>(edge_eval_, ladder_rungs_)));
+  SearchResult<FloatType> result;
 
-  // Perform the search
-  try
-  {
-    boost::dijkstra_shortest_paths(graph_,
-                                   source_,
-                                   predecessor_it_map,
-                                   distance_prop_map,
-                                   weight_prop_map,
-                                   index_prop_map,
-                                   std::less<>(),
-                                   std::plus<>(),
-                                   std::numeric_limits<FloatType>::max(),
-                                   static_cast<FloatType>(0.0),
-                                   visitor,
-                                   color_prop_map);
-  }
-  catch (const VertexDesc<FloatType>& target)
-  {
-    SearchResult<FloatType> result;
+  // Reconstruct the path from the predecesor map; remove the artificial start state
+  const auto vd_path = BGLSolverBase<FloatType, Visitors>::reconstructPath(source_, target);
+  result.trajectory = BGLSolverBase<FloatType, Visitors>::toStates(vd_path);
+  result.trajectory.erase(result.trajectory.begin());
 
-    // Reconstruct the path from the predecesor map; remove the artificial start state
-    const auto vd_path = BGLSolverBase<FloatType>::reconstructPath(source_, target);
-    result.trajectory = BGLSolverBase<FloatType>::toStates(vd_path);
-    result.trajectory.erase(result.trajectory.begin());
+  result.cost = graph_[target].distance;
 
-    result.cost = graph_[target].distance;
-
-    return result;
-  }
-
-  // If the visitor never threw the vertex descriptor, there was an issue with the search
-  throw std::runtime_error("Search failed to encounter vertex associated with the last waypoint in the trajectory");
+  return result;
 }
 
 }  // namespace descartes_light

--- a/descartes_light/solvers/include/descartes_light/solvers/bgl/impl/bgl_dijkstra_solver.hpp
+++ b/descartes_light/solvers/include/descartes_light/solvers/bgl/impl/bgl_dijkstra_solver.hpp
@@ -55,7 +55,9 @@ static VertexDesc<FloatType> solveDijkstra(BGLGraph<FloatType>& graph,
                                    [&](const VertexDesc<FloatType>& a, const VertexDesc<FloatType>& b) {
                                      return graph[a].distance < graph[b].distance;
                                    });
-    if (target != ladder_rungs.back().end())
+
+    // Check that the identified lowest cost vertex is valid and has a cost less than inf
+    if (target != ladder_rungs.back().end() && graph[*target].distance < std::numeric_limits<FloatType>::max())
       throw *target;
   }
   catch (const VertexDesc<FloatType>& target)

--- a/descartes_light/solvers/include/descartes_light/solvers/bgl/impl/event_visitors.hpp
+++ b/descartes_light/solvers/include/descartes_light/solvers/bgl/impl/event_visitors.hpp
@@ -5,13 +5,14 @@
 
 namespace descartes_light
 {
-template <typename FloatType, typename EventType>
-early_terminator<FloatType, EventType>::early_terminator(long last_rung_idx) : last_rung_idx_(last_rung_idx)
+template <typename EventType>
+early_terminator<EventType>::early_terminator(long last_rung_idx) : last_rung_idx_(last_rung_idx)
 {
 }
 
-template <typename FloatType, typename EventType>
-void early_terminator<FloatType, EventType>::operator()(VertexDesc<FloatType> u, const BGLGraph<FloatType>& g)
+template <typename EventType>
+template <typename FloatType>
+void early_terminator<EventType>::operator()(VertexDesc<FloatType> u, const BGLGraph<FloatType>& g)
 {
   if (g[u].rung_idx == last_rung_idx_)
     throw u;
@@ -55,7 +56,7 @@ void add_all_edges_dynamically<FloatType, EventType>::operator()(VertexDesc<Floa
 }
 
 template <typename FloatType>
-void cost_recorder<FloatType>::operator()(EdgeDesc<FloatType> e, const BGLGraph<FloatType>& g)
+void cost_recorder::operator()(EdgeDesc<FloatType> e, const BGLGraph<FloatType>& g)
 {
   VertexDesc<FloatType> target = boost::target(e, g);
   VertexDesc<FloatType> source = boost::source(e, g);

--- a/descartes_light/solvers/include/descartes_light/solvers/bgl/impl/event_visitors.hpp
+++ b/descartes_light/solvers/include/descartes_light/solvers/bgl/impl/event_visitors.hpp
@@ -1,105 +1,70 @@
 #ifndef DESCARTES_LIGHT_SOLVERS_BGL_IMPL_EVENT_VISITORS_HPP
 #define DESCARTES_LIGHT_SOLVERS_BGL_IMPL_EVENT_VISITORS_HPP
 
-#include <descartes_light/solvers/bgl/boost_graph_types.h>
-
-#include <descartes_light/descartes_macros.h>
-DESCARTES_IGNORE_WARNINGS_PUSH
-#include <boost/graph/visitors.hpp>
-DESCARTES_IGNORE_WARNINGS_POP
+#include <descartes_light/solvers/bgl/event_visitors.h>
 
 namespace descartes_light
 {
-/**
- * @brief Event visitor that terminates the search when a vertex in the last rung of the graph is examined
- * @details Throws the vertex descriptor that is the termination of the path once a vertex in the last rung of
- * the graph is operated on
- */
 template <typename FloatType, typename EventType>
-struct early_terminator : public boost::base_visitor<early_terminator<FloatType, EventType>>
+early_terminator<FloatType, EventType>::early_terminator(long last_rung_idx) : last_rung_idx_(last_rung_idx)
 {
-  /** @brief Event filter typedef defining the events for which this visitor can be used */
-  typedef EventType event_filter;
+}
 
-  early_terminator(long last_rung_idx) : last_rung_idx_(last_rung_idx) {}
-
-  void operator()(VertexDesc<FloatType> u, const BGLGraph<FloatType>& g)
-  {
-    if (g[u].rung_idx == last_rung_idx_)
-      throw u;
-  }
-
-  const long last_rung_idx_;
-};
-
-/**
- * @brief Event visitor that adds all edges to each vertex dynamically as the vertex is discovered during the graph
- * search
- */
 template <typename FloatType, typename EventType>
-struct add_all_edges_dynamically : public boost::base_visitor<add_all_edges_dynamically<FloatType, EventType>>
+void early_terminator<FloatType, EventType>::operator()(VertexDesc<FloatType> u, const BGLGraph<FloatType>& g)
 {
-  /** @brief Event filter typedef defining the events for which this visitor can be used */
-  typedef EventType event_filter;
+  if (g[u].rung_idx == last_rung_idx_)
+    throw u;
+}
 
-  add_all_edges_dynamically(std::vector<typename EdgeEvaluator<FloatType>::ConstPtr> edge_eval,
-                            std::vector<std::vector<VertexDesc<FloatType>>> ladder_rungs)
-    : eval_(std::move(edge_eval)), ladder_rungs_(std::move(ladder_rungs))
-  {
-  }
+template <typename FloatType, typename EventType>
+add_all_edges_dynamically<FloatType, EventType>::add_all_edges_dynamically(
+    std::vector<typename EdgeEvaluator<FloatType>::ConstPtr> edge_eval,
+    std::vector<std::vector<VertexDesc<FloatType>>> ladder_rungs)
+  : eval_(std::move(edge_eval)), ladder_rungs_(std::move(ladder_rungs))
+{
+}
 
-  void operator()(VertexDesc<FloatType> u, const BGLGraph<FloatType>& g)
+template <typename FloatType, typename EventType>
+void add_all_edges_dynamically<FloatType, EventType>::operator()(VertexDesc<FloatType> u, const BGLGraph<FloatType>& g)
+{
+  auto out_deg = boost::out_degree(u, g);
+  // return if the vertex has any out edges
+  if (out_deg == 0)
   {
-    auto out_deg = boost::out_degree(u, g);
-    // return if the vertex has any out edges
-    if (out_deg == 0)
+    std::size_t current_rung = static_cast<std::size_t>(g[u].rung_idx);
+    std::size_t next_rung = static_cast<std::size_t>(current_rung + 1);
+    if (next_rung < ladder_rungs_.size())
     {
-      std::size_t current_rung = static_cast<std::size_t>(g[u].rung_idx);
-      std::size_t next_rung = static_cast<std::size_t>(current_rung + 1);
-      if (next_rung < ladder_rungs_.size())
+      for (std::size_t s = 0; s < ladder_rungs_[next_rung].size(); ++s)
       {
-        for (std::size_t s = 0; s < ladder_rungs_[next_rung].size(); ++s)
+        std::pair<bool, FloatType> results =
+            eval_[current_rung]->evaluate(*g[u].sample.state, *g[ladder_rungs_[next_rung][s]].sample.state);
+        if (results.first)
         {
-          std::pair<bool, FloatType> results = eval_[static_cast<size_t>(current_rung)]->evaluate(
-              *g[u].sample.state, *g[ladder_rungs_[next_rung][s]].sample.state);
-          if (results.first)
-          {
-            FloatType cost = results.second + g[ladder_rungs_[next_rung][s]].sample.cost;
-            if (current_rung == 0)
-              cost += g[u].sample.cost;
-            VertexDesc<FloatType> target_vert = ladder_rungs_[next_rung][s];
-            BGLGraph<FloatType>* mutable_graph_ = const_cast<BGLGraph<FloatType>*>(&g);
-            boost::add_edge(u, target_vert, cost, *mutable_graph_);
-          }
+          FloatType cost = results.second + g[ladder_rungs_[next_rung][s]].sample.cost;
+          if (current_rung == 0)
+            cost += g[u].sample.cost;
+          VertexDesc<FloatType> target_vert = ladder_rungs_[next_rung][s];
+          BGLGraph<FloatType>* mutable_graph_ = const_cast<BGLGraph<FloatType>*>(&g);
+          boost::add_edge(u, target_vert, cost, *mutable_graph_);
         }
       }
     }
   }
+}
 
-  const std::vector<typename EdgeEvaluator<FloatType>::ConstPtr> eval_;
-  const std::vector<std::vector<VertexDesc<FloatType>>> ladder_rungs_;
-};
-
-/**
- * @brief Event visitor for updating vertex cost
- */
 template <typename FloatType>
-struct cost_recorder : public boost::base_visitor<cost_recorder<FloatType>>
+void cost_recorder<FloatType>::operator()(EdgeDesc<FloatType> e, const BGLGraph<FloatType>& g)
 {
-  /** @brief Event filter typedef defining the events for which this visitor can be used */
-  typedef boost::on_tree_edge event_filter;
+  VertexDesc<FloatType> target = boost::target(e, g);
+  VertexDesc<FloatType> source = boost::source(e, g);
+  auto edge_weight_map = boost::get(boost::edge_weight, g);
 
-  void operator()(EdgeDesc<FloatType> e, const BGLGraph<FloatType>& g)
-  {
-    VertexDesc<FloatType> target = boost::target(e, g);
-    VertexDesc<FloatType> source = boost::source(e, g);
-    auto edge_weight_map = boost::get(boost::edge_weight, g);
+  BGLGraph<FloatType>* mutable_graph_ = const_cast<BGLGraph<FloatType>*>(&g);
 
-    BGLGraph<FloatType>* mutable_graph_ = const_cast<BGLGraph<FloatType>*>(&g);
-
-    mutable_graph_->operator[](target).distance = g[source].distance + g[target].sample.cost + edge_weight_map[e];
-  }
-};
+  mutable_graph_->operator[](target).distance = g[source].distance + g[target].sample.cost + edge_weight_map[e];
+}
 
 }  // namespace descartes_light
 

--- a/descartes_light/solvers/src/bgl/bgl_solver.cpp
+++ b/descartes_light/solvers/src/bgl/bgl_solver.cpp
@@ -22,7 +22,26 @@
 #include <descartes_light/descartes_macros.h>
 DESCARTES_IGNORE_WARNINGS_PUSH
 #include <boost/graph/visitors.hpp>
+#include <boost/preprocessor.hpp>
 DESCARTES_IGNORE_WARNINGS_POP
+
+// Macro for explicitly instantiating a class with a variable number of template arguments
+#define INSTANTIATE(T, ...) template class T<__VA_ARGS__>;
+
+// Implementation macro for explicitly instantiating a class for a specific element of the Cartesian product (class_name, (template params))
+#define INSTANTIATE_PRODUCT_IMPL(r, product) \
+  INSTANTIATE(BOOST_PP_SEQ_HEAD(product), BOOST_PP_SEQ_ENUM(BOOST_PP_SEQ_TAIL(product)))
+
+/**
+ * Macro for instantiating a template class for a Cartesian product of float types and event visitor types
+ * For example, instantiation of class Foo with types ((float)(double)) and visitors ((A)(B)) would result in 4 instantiations:
+ *   - Foo<float, A>
+ *   - Foo<float, B>
+ *   - Foo<double, A>
+ *   - Foo<double, B>
+ */
+#define INSTANTIATE_PRODUCT(TEMPLATE, FLOAT_TYPES, EVENT_VISITORS) \
+  BOOST_PP_SEQ_FOR_EACH_PRODUCT(INSTANTIATE_PRODUCT_IMPL, ((TEMPLATE))(FLOAT_TYPES)(EVENT_VISITORS))
 
 namespace descartes_light
 {
@@ -33,32 +52,17 @@ template struct add_all_edges_dynamically<float, boost::on_examine_vertex>;
 template struct add_all_edges_dynamically<double, boost::on_examine_vertex>;
 
 // Explicit template instantiation
+#define FLOAT_TYPES (double)(float)
+#define DIJKSTRA_EVENT_VISITORS (boost::null_visitor)(early_terminator<boost::on_examine_vertex>)
+
 // Partial implementations
-template class BGLSolverBase<double, early_terminator<boost::on_examine_vertex>>;
-template class BGLSolverBase<float, early_terminator<boost::on_examine_vertex>>;
-template class BGLSolverBase<double, boost::null_visitor>;
-template class BGLSolverBase<float, boost::null_visitor>;
+INSTANTIATE_PRODUCT(BGLSolverBase, FLOAT_TYPES, DIJKSTRA_EVENT_VISITORS)
+INSTANTIATE_PRODUCT(BGLSolverBaseSVSE, FLOAT_TYPES, DIJKSTRA_EVENT_VISITORS)
+INSTANTIATE_PRODUCT(BGLSolverBaseSVDE, FLOAT_TYPES, DIJKSTRA_EVENT_VISITORS)
 
-template class BGLSolverBaseSVDE<double, early_terminator<boost::on_examine_vertex>>;
-template class BGLSolverBaseSVDE<float, early_terminator<boost::on_examine_vertex>>;
-template class BGLSolverBaseSVDE<double, boost::null_visitor>;
-template class BGLSolverBaseSVDE<float, boost::null_visitor>;
-
-template class BGLSolverBaseSVSE<double, early_terminator<boost::on_examine_vertex>>;
-template class BGLSolverBaseSVSE<float, early_terminator<boost::on_examine_vertex>>;
-template class BGLSolverBaseSVSE<double, boost::null_visitor>;
-template class BGLSolverBaseSVSE<float, boost::null_visitor>;
-
-// Full Implementations
-template class BGLDijkstraSVDESolver<double, early_terminator<boost::on_examine_vertex>>;
-template class BGLDijkstraSVDESolver<float, early_terminator<boost::on_examine_vertex>>;
-template class BGLDijkstraSVDESolver<double, boost::null_visitor>;
-template class BGLDijkstraSVDESolver<float, boost::null_visitor>;
-
-template class BGLDijkstraSVSESolver<double, early_terminator<boost::on_examine_vertex>>;
-template class BGLDijkstraSVSESolver<float, early_terminator<boost::on_examine_vertex>>;
-template class BGLDijkstraSVSESolver<double, boost::null_visitor>;
-template class BGLDijkstraSVSESolver<float, boost::null_visitor>;
+// BGL Dijkstra search
+INSTANTIATE_PRODUCT(BGLDijkstraSVSESolver, FLOAT_TYPES, DIJKSTRA_EVENT_VISITORS)
+INSTANTIATE_PRODUCT(BGLDijkstraSVDESolver, FLOAT_TYPES, DIJKSTRA_EVENT_VISITORS)
 
 // Free functions
 template SubGraph<double> createDecoratedSubGraph(const BGLGraph<double>& g);

--- a/descartes_light/solvers/src/bgl/bgl_solver.cpp
+++ b/descartes_light/solvers/src/bgl/bgl_solver.cpp
@@ -27,37 +27,36 @@ DESCARTES_IGNORE_WARNINGS_POP
 namespace descartes_light
 {
 // Event visitors
-template struct early_terminator<double, boost::on_examine_vertex>;
-template struct early_terminator<float, boost::on_examine_vertex>;
+template struct early_terminator<boost::on_examine_vertex>;
 
 template struct add_all_edges_dynamically<float, boost::on_examine_vertex>;
 template struct add_all_edges_dynamically<double, boost::on_examine_vertex>;
 
 // Explicit template instantiation
 // Partial implementations
-template class BGLSolverBase<double, early_terminator<double, boost::on_examine_vertex>>;
-template class BGLSolverBase<float, early_terminator<float, boost::on_examine_vertex>>;
+template class BGLSolverBase<double, early_terminator<boost::on_examine_vertex>>;
+template class BGLSolverBase<float, early_terminator<boost::on_examine_vertex>>;
 template class BGLSolverBase<double, boost::null_visitor>;
 template class BGLSolverBase<float, boost::null_visitor>;
 
-template class BGLSolverBaseSVDE<double, early_terminator<double, boost::on_examine_vertex>>;
-template class BGLSolverBaseSVDE<float, early_terminator<float, boost::on_examine_vertex>>;
+template class BGLSolverBaseSVDE<double, early_terminator<boost::on_examine_vertex>>;
+template class BGLSolverBaseSVDE<float, early_terminator<boost::on_examine_vertex>>;
 template class BGLSolverBaseSVDE<double, boost::null_visitor>;
 template class BGLSolverBaseSVDE<float, boost::null_visitor>;
 
-template class BGLSolverBaseSVSE<double, early_terminator<double, boost::on_examine_vertex>>;
-template class BGLSolverBaseSVSE<float, early_terminator<float, boost::on_examine_vertex>>;
+template class BGLSolverBaseSVSE<double, early_terminator<boost::on_examine_vertex>>;
+template class BGLSolverBaseSVSE<float, early_terminator<boost::on_examine_vertex>>;
 template class BGLSolverBaseSVSE<double, boost::null_visitor>;
 template class BGLSolverBaseSVSE<float, boost::null_visitor>;
 
 // Full Implementations
-template class BGLDijkstraSVDESolver<double, early_terminator<double, boost::on_examine_vertex>>;
-template class BGLDijkstraSVDESolver<float, early_terminator<float, boost::on_examine_vertex>>;
+template class BGLDijkstraSVDESolver<double, early_terminator<boost::on_examine_vertex>>;
+template class BGLDijkstraSVDESolver<float, early_terminator<boost::on_examine_vertex>>;
 template class BGLDijkstraSVDESolver<double, boost::null_visitor>;
 template class BGLDijkstraSVDESolver<float, boost::null_visitor>;
 
-template class BGLDijkstraSVSESolver<double, early_terminator<double, boost::on_examine_vertex>>;
-template class BGLDijkstraSVSESolver<float, early_terminator<float, boost::on_examine_vertex>>;
+template class BGLDijkstraSVSESolver<double, early_terminator<boost::on_examine_vertex>>;
+template class BGLDijkstraSVSESolver<float, early_terminator<boost::on_examine_vertex>>;
 template class BGLDijkstraSVSESolver<double, boost::null_visitor>;
 template class BGLDijkstraSVSESolver<float, boost::null_visitor>;
 

--- a/descartes_light/solvers/src/bgl/bgl_solver.cpp
+++ b/descartes_light/solvers/src/bgl/bgl_solver.cpp
@@ -28,19 +28,21 @@ DESCARTES_IGNORE_WARNINGS_POP
 // Macro for explicitly instantiating a class with a variable number of template arguments
 #define INSTANTIATE(T, ...) template class T<__VA_ARGS__>;
 
-// Implementation macro for explicitly instantiating a class for a specific element of the Cartesian product (class_name, (template params))
-#define INSTANTIATE_PRODUCT_IMPL(r, product) \
+// Implementation macro for explicitly instantiating a class for a specific element of the Cartesian product
+// (class_name, (template params))
+#define INSTANTIATE_PRODUCT_IMPL(r, product)                                                                           \
   INSTANTIATE(BOOST_PP_SEQ_HEAD(product), BOOST_PP_SEQ_ENUM(BOOST_PP_SEQ_TAIL(product)))
 
 /**
  * Macro for instantiating a template class for a Cartesian product of float types and event visitor types
- * For example, instantiation of class Foo with types ((float)(double)) and visitors ((A)(B)) would result in 4 instantiations:
+ * For example, instantiation of class Foo with types ((float)(double)) and visitors ((A)(B)) would result in 4
+ * instantiations:
  *   - Foo<float, A>
  *   - Foo<float, B>
  *   - Foo<double, A>
  *   - Foo<double, B>
  */
-#define INSTANTIATE_PRODUCT(TEMPLATE, FLOAT_TYPES, EVENT_VISITORS) \
+#define INSTANTIATE_PRODUCT(TEMPLATE, FLOAT_TYPES, EVENT_VISITORS)                                                     \
   BOOST_PP_SEQ_FOR_EACH_PRODUCT(INSTANTIATE_PRODUCT_IMPL, ((TEMPLATE))(FLOAT_TYPES)(EVENT_VISITORS))
 
 namespace descartes_light

--- a/descartes_light/solvers/src/bgl/bgl_solver.cpp
+++ b/descartes_light/solvers/src/bgl/bgl_solver.cpp
@@ -19,31 +19,48 @@
 #include <descartes_light/solvers/bgl/impl/bgl_dijkstra_solver.hpp>
 #include <descartes_light/solvers/bgl/impl/utils.hpp>
 
+#include <descartes_light/descartes_macros.h>
+DESCARTES_IGNORE_WARNINGS_PUSH
+#include <boost/graph/visitors.hpp>
+DESCARTES_IGNORE_WARNINGS_POP
+
 namespace descartes_light
 {
+// Event visitors
+template struct early_terminator<double, boost::on_examine_vertex>;
+template struct early_terminator<float, boost::on_examine_vertex>;
+
+template struct add_all_edges_dynamically<float, boost::on_examine_vertex>;
+template struct add_all_edges_dynamically<double, boost::on_examine_vertex>;
+
 // Explicit template instantiation
 // Partial implementations
-template class BGLSolverBase<double>;
-template class BGLSolverBase<float>;
+template class BGLSolverBase<double, early_terminator<double, boost::on_examine_vertex>>;
+template class BGLSolverBase<float, early_terminator<float, boost::on_examine_vertex>>;
+template class BGLSolverBase<double, boost::null_visitor>;
+template class BGLSolverBase<float, boost::null_visitor>;
 
-template class BGLSolverBaseSVDE<double>;
-template class BGLSolverBaseSVDE<float>;
+template class BGLSolverBaseSVDE<double, early_terminator<double, boost::on_examine_vertex>>;
+template class BGLSolverBaseSVDE<float, early_terminator<float, boost::on_examine_vertex>>;
+template class BGLSolverBaseSVDE<double, boost::null_visitor>;
+template class BGLSolverBaseSVDE<float, boost::null_visitor>;
 
-template class BGLSolverBaseSVSE<double>;
-template class BGLSolverBaseSVSE<float>;
+template class BGLSolverBaseSVSE<double, early_terminator<double, boost::on_examine_vertex>>;
+template class BGLSolverBaseSVSE<float, early_terminator<float, boost::on_examine_vertex>>;
+template class BGLSolverBaseSVSE<double, boost::null_visitor>;
+template class BGLSolverBaseSVSE<float, boost::null_visitor>;
 
 // Full Implementations
-template class BGLDijkstraSVSESolver<double>;
-template class BGLDijkstraSVSESolver<float>;
+template class BGLDijkstraSVDESolver<double, early_terminator<double, boost::on_examine_vertex>>;
+template class BGLDijkstraSVDESolver<float, early_terminator<float, boost::on_examine_vertex>>;
+template class BGLDijkstraSVDESolver<double, boost::null_visitor>;
+template class BGLDijkstraSVDESolver<float, boost::null_visitor>;
 
-template class BGLEfficientDijkstraSVSESolver<double>;
-template class BGLEfficientDijkstraSVSESolver<float>;
+template class BGLDijkstraSVSESolver<double, early_terminator<double, boost::on_examine_vertex>>;
+template class BGLDijkstraSVSESolver<float, early_terminator<float, boost::on_examine_vertex>>;
+template class BGLDijkstraSVSESolver<double, boost::null_visitor>;
+template class BGLDijkstraSVSESolver<float, boost::null_visitor>;
 
-template class BGLDijkstraSVDESolver<double>;
-template class BGLDijkstraSVDESolver<float>;
-
-template class BGLEfficientDijkstraSVDESolver<double>;
-template class BGLEfficientDijkstraSVDESolver<float>;
 // Free functions
 template SubGraph<double> createDecoratedSubGraph(const BGLGraph<double>& g);
 template SubGraph<float> createDecoratedSubGraph(const BGLGraph<float>& g);

--- a/descartes_light/test/benchmarks/benchmarks.cpp
+++ b/descartes_light/test/benchmarks/benchmarks.cpp
@@ -51,7 +51,7 @@ void benchmark(const SolverFactory<SolverT>& factory)
             createSamplers<FloatType>(dof, n_waypoints, samples_per_wp, state_cost);
 
         // Create the solver
-        typename descartes_light::Solver<FloatType>::Ptr solver = factory.create();
+        typename descartes_light::Solver<FloatType>::Ptr solver = factory.create(static_cast<long>(n_waypoints));
 
         // Build the graph
         auto start_time = Clock::now();
@@ -80,13 +80,21 @@ int main(int, char**)
   benchmark(SolverFactory<LadderGraphSolverD>());
   benchmark(SolverFactory<LadderGraphSolverF>());
 
-  // BGL full Dijkstra solver
+  // BGL Dijkstra full search, static vertex static edge
+  benchmark(SolverFactory<BGLDijkstraSVSESolver<double, boost::null_visitor>>());
+  benchmark(SolverFactory<BGLDijkstraSVSESolver<float, boost::null_visitor>>());
+
+  // BGL Dijkstra early termination, static vertex static edge
   benchmark(SolverFactory<BGLDijkstraSVSESolverD>());
   benchmark(SolverFactory<BGLDijkstraSVSESolverF>());
 
-  // BGL efficient Dijkstra solver
-  benchmark(SolverFactory<BGLEfficientDijkstraSVSESolverD>());
-  benchmark(SolverFactory<BGLEfficientDijkstraSVSESolverF>());
+  // BGL Dijkstra full search, static vertex dynamic edge
+  benchmark(SolverFactory<BGLDijkstraSVDESolver<double, boost::null_visitor>>());
+  benchmark(SolverFactory<BGLDijkstraSVDESolver<float, boost::null_visitor>>());
+
+  // BGL Dijkstra early termination, static vertex, dynamic edge
+  benchmark(SolverFactory<BGLDijkstraSVDESolverD>());
+  benchmark(SolverFactory<BGLDijkstraSVDESolverF>());
 
   return 0;
 }

--- a/descartes_light/test/include/descartes_light/test/impl/solver_factory.hpp
+++ b/descartes_light/test/include/descartes_light/test/impl/solver_factory.hpp
@@ -10,40 +10,50 @@ namespace descartes_light
 template <typename FloatType>
 struct SolverFactory<LadderGraphSolver<FloatType>>
 {
-  typename Solver<FloatType>::Ptr create() const { return std::make_shared<LadderGraphSolver<FloatType>>(1); }
+  typename Solver<FloatType>::Ptr create(long) const { return std::make_shared<LadderGraphSolver<FloatType>>(1); }
 };
 
 // Boost full Dijkstra graph solver factory
 template <typename FloatType>
-struct SolverFactory<BGLDijkstraSVSESolver<FloatType>>
+struct SolverFactory<BGLDijkstraSVSESolver<FloatType, boost::null_visitor>>
 {
-  typename Solver<FloatType>::Ptr create() const { return std::make_shared<BGLDijkstraSVSESolver<FloatType>>(1); }
+  using Visitors = boost::null_visitor;
+  typename Solver<FloatType>::Ptr create(long) const
+  {
+    return std::make_shared<BGLDijkstraSVSESolver<FloatType, Visitors>>(Visitors(), 1);
+  }
 };
 
 // Boost efficient Dijkstra graph solver factory
 template <typename FloatType>
-struct SolverFactory<BGLEfficientDijkstraSVSESolver<FloatType>>
+struct SolverFactory<BGLDijkstraSVSESolver<FloatType, early_terminator<FloatType, boost::on_examine_vertex>>>
 {
-  typename Solver<FloatType>::Ptr create() const
+  using Visitors = early_terminator<FloatType, boost::on_examine_vertex>;
+  typename Solver<FloatType>::Ptr create(long n_waypoints) const
   {
-    return std::make_shared<BGLEfficientDijkstraSVSESolver<FloatType>>(1);
+    return std::make_shared<BGLDijkstraSVSESolver<FloatType, Visitors>>(Visitors(n_waypoints - 1), 1);
   }
 };
 
 // Dynamic Boost full Dijkstra graph solver factory
 template <typename FloatType>
-struct SolverFactory<BGLDijkstraSVDESolver<FloatType>>
+struct SolverFactory<BGLDijkstraSVDESolver<FloatType, boost::null_visitor>>
 {
-  typename Solver<FloatType>::Ptr create() const { return std::make_shared<BGLDijkstraSVDESolver<FloatType>>(1); }
+  using Visitors = boost::null_visitor;
+  typename Solver<FloatType>::Ptr create(long) const
+  {
+    return std::make_shared<BGLDijkstraSVDESolver<FloatType, Visitors>>(Visitors(), 1);
+  }
 };
 
 // Dynamic Boost efficient Dijkstra graph solver factory
 template <typename FloatType>
-struct SolverFactory<BGLEfficientDijkstraSVDESolver<FloatType>>
+struct SolverFactory<BGLDijkstraSVDESolver<FloatType, early_terminator<FloatType, boost::on_examine_vertex>>>
 {
-  typename Solver<FloatType>::Ptr create() const
+  using Visitors = early_terminator<FloatType, boost::on_examine_vertex>;
+  typename Solver<FloatType>::Ptr create(long n_waypoints) const
   {
-    return std::make_shared<BGLEfficientDijkstraSVDESolver<FloatType>>(1);
+    return std::make_shared<BGLDijkstraSVDESolver<FloatType, Visitors>>(Visitors(n_waypoints - 1), 1);
   }
 };
 

--- a/descartes_light/test/include/descartes_light/test/impl/solver_factory.hpp
+++ b/descartes_light/test/include/descartes_light/test/impl/solver_factory.hpp
@@ -26,9 +26,9 @@ struct SolverFactory<BGLDijkstraSVSESolver<FloatType, boost::null_visitor>>
 
 // Boost efficient Dijkstra graph solver factory
 template <typename FloatType>
-struct SolverFactory<BGLDijkstraSVSESolver<FloatType, early_terminator<FloatType, boost::on_examine_vertex>>>
+struct SolverFactory<BGLDijkstraSVSESolver<FloatType, early_terminator<boost::on_examine_vertex>>>
 {
-  using Visitors = early_terminator<FloatType, boost::on_examine_vertex>;
+  using Visitors = early_terminator<boost::on_examine_vertex>;
   typename Solver<FloatType>::Ptr create(long n_waypoints) const
   {
     return std::make_shared<BGLDijkstraSVSESolver<FloatType, Visitors>>(Visitors(n_waypoints - 1), 1);
@@ -48,9 +48,9 @@ struct SolverFactory<BGLDijkstraSVDESolver<FloatType, boost::null_visitor>>
 
 // Dynamic Boost efficient Dijkstra graph solver factory
 template <typename FloatType>
-struct SolverFactory<BGLDijkstraSVDESolver<FloatType, early_terminator<FloatType, boost::on_examine_vertex>>>
+struct SolverFactory<BGLDijkstraSVDESolver<FloatType, early_terminator<boost::on_examine_vertex>>>
 {
-  using Visitors = early_terminator<FloatType, boost::on_examine_vertex>;
+  using Visitors = early_terminator<boost::on_examine_vertex>;
   typename Solver<FloatType>::Ptr create(long n_waypoints) const
   {
     return std::make_shared<BGLDijkstraSVDESolver<FloatType, Visitors>>(Visitors(n_waypoints - 1), 1);

--- a/descartes_light/test/include/descartes_light/test/solver_factory.h
+++ b/descartes_light/test/include/descartes_light/test/solver_factory.h
@@ -11,7 +11,7 @@ template <typename SolverT>
 struct SolverFactory
 {
   using FloatType = typename SolverT::FloatT;
-  typename Solver<FloatType>::Ptr create() const;
+  typename Solver<FloatType>::Ptr create(long n_waypoints) const;
 };
 
 }  // namespace descartes_light

--- a/descartes_light/test/src/solver_factory.cpp
+++ b/descartes_light/test/src/solver_factory.cpp
@@ -4,12 +4,17 @@ namespace descartes_light
 {
 template struct SolverFactory<LadderGraphSolverF>;
 template struct SolverFactory<LadderGraphSolverD>;
+// Naive BGL Dijkstra search, static vertex static edge
+template struct SolverFactory<BGLDijkstraSVSESolver<float, boost::null_visitor>>;
+template struct SolverFactory<BGLDijkstraSVSESolver<double, boost::null_visitor>>;
+// BGL Dijkstra search with early termination, static vertex static edge
 template struct SolverFactory<BGLDijkstraSVSESolverF>;
 template struct SolverFactory<BGLDijkstraSVSESolverD>;
-template struct SolverFactory<BGLEfficientDijkstraSVSESolverF>;
-template struct SolverFactory<BGLEfficientDijkstraSVSESolverD>;
+// Naive BGL Dijkstra search, static vertex dynamic edge
+template struct SolverFactory<BGLDijkstraSVDESolver<float, boost::null_visitor>>;
+template struct SolverFactory<BGLDijkstraSVDESolver<double, boost::null_visitor>>;
+// BGL Dijkstra searhc with early termination, static vertex dynamic edge
 template struct SolverFactory<BGLDijkstraSVDESolverF>;
 template struct SolverFactory<BGLDijkstraSVDESolverD>;
-template struct SolverFactory<BGLEfficientDijkstraSVDESolverF>;
-template struct SolverFactory<BGLEfficientDijkstraSVDESolverD>;
+
 }  // namespace descartes_light

--- a/descartes_light/test/utest.cpp
+++ b/descartes_light/test/utest.cpp
@@ -41,21 +41,21 @@ public:
 
 using Implementations = ::testing::Types<SolverFactory<LadderGraphSolverF>,
                                          SolverFactory<LadderGraphSolverD>,
+                                         SolverFactory<BGLDijkstraSVSESolver<float, boost::null_visitor>>,
+                                         SolverFactory<BGLDijkstraSVSESolver<double, boost::null_visitor>>,
                                          SolverFactory<BGLDijkstraSVSESolverF>,
                                          SolverFactory<BGLDijkstraSVSESolverD>,
-                                         SolverFactory<BGLEfficientDijkstraSVSESolverF>,
-                                         SolverFactory<BGLEfficientDijkstraSVSESolverD>,
+                                         SolverFactory<BGLDijkstraSVDESolver<float, boost::null_visitor>>,
+                                         SolverFactory<BGLDijkstraSVDESolver<double, boost::null_visitor>>,
                                          SolverFactory<BGLDijkstraSVDESolverF>,
-                                         SolverFactory<BGLDijkstraSVDESolverD>,
-                                         SolverFactory<BGLEfficientDijkstraSVDESolverF>,
-                                         SolverFactory<BGLEfficientDijkstraSVDESolverD>>;
+                                         SolverFactory<BGLDijkstraSVDESolverD>>;
 
 TYPED_TEST_CASE(SolverFixture, Implementations);
 
 TYPED_TEST(SolverFixture, KnownPathTest)
 {
   using FloatType = typename TypeParam::FloatType;
-  typename Solver<FloatType>::Ptr solver = this->Factory.create();
+  typename Solver<FloatType>::Ptr solver = this->Factory.create(static_cast<long>(this->n_waypoints));
 
   // Build a graph where one sample for each waypoint is an all zero state; evaluate edges using the Euclidean distance
   // metric Since each waypoint has an all-zero state, the shortest path should be through these samples


### PR DESCRIPTION
This PR adds a template parameter to the BGL solver classes for generically specifying the event visitors to use in the search. Since the event visitors themselves do not inherit from a single base class, they can only be specified and stored within the search class using an additional template parameter. This makes the instantiation of the BGL search classes more difficult, but prevents the need for creating separate class instances for every useful combination of event visitors that a search might need. 

In order to make the BGL search classes a little more user-friendly, the `BGLDijkstraSVSESolverD/F` and `BGLDijkstraSVDESolverD/F` typedefs represent the configuration of the "most effective" solvers (currently using the early terminator event visitor). Additionally a few macros were created for explicitly instantiating template classes for a Cartesian product of template parameters (i.e. float types with event visitor types), so the instantiation of each solver with every combination of float type with event visitor does not have to be manually specified.

Addresses #79 