### PR TITLE
Remove dependency on catkin

### DIFF
--- a/descartes_light/package.xml
+++ b/descartes_light/package.xml
@@ -8,8 +8,6 @@
   <maintainer email="levi.armstrong@swri.org">Levi Armstrong</maintainer>
   <license>Apache 2.0</license>
 
-  <!-- Following recommendations of REP 136 -->
-  <exec_depend>catkin</exec_depend>
   <buildtool_depend>cmake</buildtool_depend>
 
   <depend>libconsole-bridge-dev</depend>


### PR DESCRIPTION
Unnecessarily confuses rosdep when this is being used in a ROS2 system. The mentioned ROS REP long predates ROS2 and I think can safely be ignored now.