### PR TITLE
Added default state evaluator that treats all states equally

### DIFF
--- a/descartes_light/core/include/descartes_light/core/state_evaluator.h
+++ b/descartes_light/core/include/descartes_light/core/state_evaluator.h
@@ -42,7 +42,10 @@ public:
   StateEvaluator(StateEvaluator&&) noexcept = default;
   StateEvaluator& operator=(StateEvaluator&&) noexcept = default;
 
-  virtual std::pair<bool, FloatType> evaluate(const State<FloatType>& solution) const = 0;
+  virtual std::pair<bool, FloatType> evaluate(const State<FloatType>& solution) const
+  {
+    return std::make_pair<bool, FloatType>(true, static_cast<FloatType>(0.0));
+  };
 };
 
 using StateEvaluatorF = StateEvaluator<float>;

--- a/descartes_light/core/include/descartes_light/core/state_evaluator.h
+++ b/descartes_light/core/include/descartes_light/core/state_evaluator.h
@@ -42,7 +42,7 @@ public:
   StateEvaluator(StateEvaluator&&) noexcept = default;
   StateEvaluator& operator=(StateEvaluator&&) noexcept = default;
 
-  virtual std::pair<bool, FloatType> evaluate(const State<FloatType>& solution) const
+  virtual std::pair<bool, FloatType> evaluate(const State<FloatType>& /*solution*/) const
   {
     return std::make_pair<bool, FloatType>(true, static_cast<FloatType>(0.0));
   };


### PR DESCRIPTION
Previously the base state evaluator class had no implementation, but the default behavior should likely be that all states are treated equally unless otherwise specified.