### PR TITLE
Use johnwason/vcpkg-action action

### DIFF
--- a/.github/workflows/windows_2019.yml
+++ b/.github/workflows/windows_2019.yml
@@ -19,7 +19,7 @@ jobs:
         path: workspace/src/descartes_light
 
     - name: vcpkg build
-      uses: johnwason/vcpkg-action@v1
+      uses: johnwason/vcpkg-action@v2
       with:
         pkgs: >-
           boost-graph eigen3 console-bridge

--- a/.github/workflows/windows_2019.yml
+++ b/.github/workflows/windows_2019.yml
@@ -8,11 +8,6 @@ on:
   schedule:
     - cron: '0 5 * * *'
 
-env:
-  VCPKG_PKGS: >-
-    boost-graph eigen3 console-bridge
-  VCPKG_DEFAULT_BINARY_CACHE: ${{ github.workspace }}\vcpkg_cache
-
 jobs:
   windows_ci:
     name: Windows-2019
@@ -23,30 +18,12 @@ jobs:
       with:
         path: workspace/src/descartes_light
 
-    - name: checkout-vcpkg
-      uses: actions/checkout@master
+    - name: vcpkg build
+      uses: johnwason/vcpkg-action@v1
       with:
-        path: vcpkg
-        repository: microsoft/vcpkg
-
-    - name: bootstrap-vcpkg
-      working-directory: vcpkg
-      run: bootstrap-vcpkg.bat
-
-    - name: vcpkg-dry-run
-      working-directory: vcpkg
-      shell: cmd
-      run: |
-        mkdir %VCPKG_DEFAULT_BINARY_CACHE%
-        vcpkg install --dry-run --triplet x64-windows-release ${{ env.VCPKG_PKGS }} > vcpkg_dry_run.txt
-
-    - name: cache-vcpkg-archives
-      if: startsWith(github.ref, 'refs/tags/v') != true
-      id: cache-vcpkg-archives
-      uses: pat-s/always-upload-cache@v3
-      with:
-        path: ${{ env.VCPKG_DEFAULT_BINARY_CACHE }}
-        key: ${{ runner.os }}-x64-windows-release-vcpkg-${{ hashFiles('vcpkg/vcpkg_dry_run.txt') }}-main
+        pkgs: >-
+          boost-graph eigen3 console-bridge
+        triplet: x64-windows-release
 
     - name: install-depends
       shell: cmd
@@ -54,7 +31,6 @@ jobs:
       run: |
         vcpkg integrate install
         python -m pip install vcstool colcon-common-extensions ninja -q
-        vcpkg install --triplet x64-windows-release ${{ env.VCPKG_PKGS }}
 
     - name: configure-msvc
       uses: ilammy/msvc-dev-cmd@master


### PR DESCRIPTION
I created a github action to handle the vcpkg clone, dry run, cache, and install steps. See https://github.com/johnwason/vcpkg-action . This pull request will use this action for windows_2019.yml workflow.