### PR TITLE
Use later version of vcpkg action

### DIFF
--- a/.github/workflows/windows_2019.yml
+++ b/.github/workflows/windows_2019.yml
@@ -19,11 +19,11 @@ jobs:
         path: workspace/src/descartes_light
 
     - name: vcpkg build
-      uses: johnwason/vcpkg-action@v3
+      uses: johnwason/vcpkg-action@v4
       with:
-        pkgs: >-
-          boost-graph eigen3 console-bridge
+        pkgs: boost-graph eigen3 console-bridge
         triplet: x64-windows-release
+        token: ${{ github.token }}
 
     - name: install-depends
       shell: cmd


### PR DESCRIPTION
Change per commit message to fix failing Windows CI build