### PR TITLE
Feat/better logging

### DIFF
--- a/descartes_light/core/include/descartes_light/core/waypoint_sampler.h
+++ b/descartes_light/core/include/descartes_light/core/waypoint_sampler.h
@@ -60,7 +60,13 @@ public:
    */
   virtual typename std::vector<StateSample<FloatType>> sample() const = 0;
 
-  friend std::ostream& operator<<(std::ostream& os, const WaypointSampler<FloatType>& /*wps*/) { return os; }
+  virtual void print(std::ostream& os) const {os << "";}
+
+  friend std::ostream& operator<<(std::ostream& os, const WaypointSampler<FloatType>& wps)
+  {
+    wps.print(os);
+    return os;
+  }
 };
 
 using WaypointSamplerF = WaypointSampler<float>;

--- a/descartes_light/core/include/descartes_light/core/waypoint_sampler.h
+++ b/descartes_light/core/include/descartes_light/core/waypoint_sampler.h
@@ -60,7 +60,7 @@ public:
    */
   virtual typename std::vector<StateSample<FloatType>> sample() const = 0;
 
-  virtual void print(std::ostream& os) const {os << "";}
+  virtual void print(std::ostream&) const {}
 
   friend std::ostream& operator<<(std::ostream& os, const WaypointSampler<FloatType>& wps)
   {

--- a/descartes_light/core/include/descartes_light/solvers/ladder_graph/impl/ladder_graph_solver.hpp
+++ b/descartes_light/core/include/descartes_light/solvers/ladder_graph/impl/ladder_graph_solver.hpp
@@ -140,11 +140,9 @@ BuildStatus LadderGraphSolver<FloatType>::buildImpl(
       std::stringstream s;
       s << vert_idx << ": " << *pos;
 
-      if (console_bridge::getLogLevel() == console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_DEBUG)
-      {
-        std::cout << s.str().c_str() << std::endl;
-      }
-
+      // WARNING: CONSOLE_BRIDGE_logDebug has a limited buffer size of 1024 char, see
+      // https://github.com/ros/console_bridge/blob/7048ab4539736416fa423fd0a30744d4902333a9/src/console.cpp#L116C14-L11
+      CONSOLE_BRIDGE_logDebug("%s", s.str().c_str());
     }
   }
   // Build Edges

--- a/descartes_light/core/include/descartes_light/solvers/ladder_graph/impl/ladder_graph_solver.hpp
+++ b/descartes_light/core/include/descartes_light/solvers/ladder_graph/impl/ladder_graph_solver.hpp
@@ -140,7 +140,11 @@ BuildStatus LadderGraphSolver<FloatType>::buildImpl(
       std::stringstream s;
       s << vert_idx << ": " << *pos;
 
-      CONSOLE_BRIDGE_logDebug("%s", s.str().c_str());
+      if (console_bridge::getLogLevel() == console_bridge::LogLevel::CONSOLE_BRIDGE_LOG_DEBUG)
+      {
+        std::cout << s.str().c_str() << std::endl;
+      }
+
     }
   }
   // Build Edges


### PR DESCRIPTION
Previously we had the `<< ` operator implemented, but there was no way to actually override it. Now you can override and implement the `print` method in any inherited class. Directly related to [this PR](https://github.com/tesseract-robotics/tesseract_planning/pull/401) in tesseract_planning.