### PR TITLE
Add missing <chrono> import to bgl_solver.hpp for MSVC

### DIFF
--- a/descartes_light/bgl/include/descartes_light/bgl/impl/bgl_solver.hpp
+++ b/descartes_light/bgl/include/descartes_light/bgl/impl/bgl_solver.hpp
@@ -19,6 +19,7 @@
 
 #include <descartes_light/descartes_macros.h>
 DESCARTES_IGNORE_WARNINGS_PUSH
+#include <chrono>
 #include <console_bridge/console.h>
 #include <fstream>
 #include <omp.h>


### PR DESCRIPTION
This PR fixes a compile error using MSVC.