### PR TITLE
Add shrink_to_fit call to rung nodes after filtering

### DIFF
--- a/descartes_light/core/include/descartes_light/solvers/ladder_graph/impl/ladder_graph_solver.hpp
+++ b/descartes_light/core/include/descartes_light/solvers/ladder_graph/impl/ladder_graph_solver.hpp
@@ -110,6 +110,8 @@ BuildStatus LadderGraphSolver<FloatType>::buildImpl(
           }
         }
       }
+      // The state evaluator will filter samples so capacity should be reduced when finished
+      r.nodes.shrink_to_fit();
     }
     else
     {


### PR DESCRIPTION
In tesseract when using robot on position it can generate a lot of IK Solutions which then get filtered out by various validators. In one of my test cause where a majority of samples were being filter it still consumed a significant amount of memory. After further investigation I found that we reserve space for all samples but do not shrink to fit after all samples have bin validated. This can lead to a lot of memory being used when it is not used. This adds a shrink to fit call on the rung nodes after the filtering process to improve memory usage. 